### PR TITLE
Patch 3

### DIFF
--- a/renamed-styles.json
+++ b/renamed-styles.json
@@ -464,6 +464,7 @@
     "trends-journal": "trends-journals",
     "tu-wien-dissertation": "technische-universitat-wien",
     "ulster-medical-journal": "the-ulster-medical-journal",
+    "uludag-universitesi-sosyal-bilimler-enstitusu-full-note-no-ibid": "uludag-universitesi-sosyal-bilimler-enstitusu-full-note",
     "uludag-universitesi-sosyal-bilimler-enstitusu-note": "uludag-universitesi-sosyal-bilimler-enstitusu-full-note",
     "un-eclac-cepal-english": "economic-commission-for-latin-america-and-the-caribbean",
     "un-eclac-cepal-spanish": "comision-economica-para-america-latina-y-el-caribe",

--- a/transactions-of-the-american-philological-association.csl
+++ b/transactions-of-the-american-philological-association.csl
@@ -20,6 +20,10 @@
       <name>Sebastian Karcher</name>
     </contributor>
     <contributor>
+      <name>Kenneth Mayer</name>
+      <email>ken.i.mayer@gmail.com</email>
+    </contributor>
+    <contributor>
       <name>Richard Karnesky</name>
       <email>karnesky+zotero@gmail.com</email>
       <uri>http://arc.nucapt.northwestern.edu/Richard_Karnesky</uri>
@@ -29,7 +33,7 @@
     <issn>0360-5949</issn>
     <eissn>1533-0699</eissn>
     <summary>The author-date variant of the Chicago style with TAPA modifications (colon before page, no parentheses)</summary>
-    <updated>2013-04-13T17:12:15+00:00</updated>
+    <updated>2017-11-07T13:37:33+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -66,12 +70,12 @@
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <group prefix=", " delimiter=", ">
+        <group delimiter=", " suffix=", ">
           <choose>
             <if variable="author">
               <names variable="container-author editor" delimiter=", ">
-                <label form="verb" suffix=" " plural="never"/>
-                <name and="text" delimiter=", "/>
+                <name and="text" initialize-with="." name-as-sort-order="all"/>
+                <label form="short"/>
               </names>
             </if>
           </choose>
@@ -107,7 +111,7 @@
   </macro>
   <macro name="contributors">
     <names variable="author">
-      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <name and="text" delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all"/>
       <label form="short" plural="never" prefix=", "/>
       <substitute>
         <names variable="editor"/>
@@ -338,7 +342,8 @@
     </choose>
     <choose>
       <if type="legal_case" match="none">
-        <text variable="container-title" text-case="title" font-style="italic"/>
+        <text macro="container-contributors"/>
+        <text variable="container-title" form="short" text-case="title" font-style="italic"/>
       </if>
     </choose>
   </macro>
@@ -450,7 +455,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="���" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
     <sort>
       <key macro="contributors"/>
       <key variable="issued"/>
@@ -464,7 +469,6 @@
       <text macro="description"/>
       <text macro="secondary-contributors" prefix=". "/>
       <text macro="container-title" prefix=". "/>
-      <text macro="container-contributors"/>
       <text macro="edition"/>
       <text macro="locators-chapter"/>
       <text macro="locators"/>

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-author-date.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-author-date.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="social_science"/>
     <summary>Uludağ Üniversitesi Sosyal Bilimler Enstitüsü tez yazım kılavuzuna göre hazırlanmıştır.</summary>
-    <updated>2017-10-01T08:50:51+00:00</updated>
+    <updated>2017-10-26T06:45:06+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="tr">
@@ -126,12 +126,16 @@
     </names>
   </macro>
   <macro name="archive">
-    <group delimiter=", ">
-      <text variable="archive"/>
-      <text variable="archive_location" text-case="capitalize-first"/>
-      <text variable="archive-place"/>
-      <text variable="call-number"/>
-    </group>
+    <choose>
+      <if type="manuscript" match="any">
+        <group delimiter=", ">
+          <text variable="archive"/>
+          <text variable="archive_location" text-case="capitalize-first"/>
+          <text variable="archive-place"/>
+          <text variable="call-number"/>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="access">
     <group delimiter=", ">
@@ -159,7 +163,7 @@
         </if>
       </choose>
       <choose>
-        <if type="legal_case" match="none">
+        <if type="legal_case thesis book" match="none">
           <choose>
             <if variable="DOI">
               <text variable="DOI" prefix="doi:"/>
@@ -491,7 +495,7 @@
   </macro>
   <macro name="collection-title">
     <choose>
-      <if match="none" type="article-journal">
+      <if match="none" type="article-journal book">
         <choose>
           <if match="none" is-numeric="collection-number">
             <group delimiter=", ">

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-full-note-with-ibid.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-full-note-with-ibid.csl
@@ -2,9 +2,9 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-et-al="never" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" page-range-format="chicago" default-locale="tr-TR">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Uludağ Üniversitesi - Sosyal Bilimler Enstitüsü (full note, no Ibid., Turkish)</title>
-    <id>http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-full-note-no-ibid</id>
-    <link href="http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-full-note-no-ibid" rel="self"/>
+    <title>Uludağ Üniversitesi - Sosyal Bilimler Enstitüsü (full note, with Ibid., Turkish)</title>
+    <id>http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-full-note-with-ibid</id>
+    <link href="http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-full-note-with-ibid" rel="self"/>
     <link href="http://www.zotero.org/styles/chicago-fullnote-bibliography" rel="template"/>
     <link href="http://www.uludag.edu.tr/dosyalar/sosyalbilimler/2016%20Duyurular/SBE%20TEZ%20YAZ.%20KIL.(YEN%C4%B0)%2023.09.2016%20(1).pdf" xml:lang="tr" rel="documentation"/>
     <author>
@@ -14,7 +14,7 @@
     <category citation-format="note"/>
     <category field="social_science"/>
     <summary xml:lang="tr">Uludağ Üniversitesi Sosyal Bilimler Enstitüsü'nde yüksek lisans ve doktora tezi yazan öğrencilerimiz için tez yazım kılavuzuna uygun olarak hazırlanmıştır.</summary>
-    <updated>2017-10-09T21:22:19+00:00</updated>
+    <updated>2017-11-01T11:02:44+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="tr">
@@ -32,9 +32,11 @@
       </term>
       <term name="translator" form="short">çev.</term>
       <term name="edition" form="short">bs.</term>
-      <term name="issue" form="short">s.</term>
-      <term name="volume" form="short">c.</term>
+      <term name="ibid">a.yer</term>
+      <term name="issue" form="short">S.</term>
+      <term name="volume" form="short">C.</term>
       <term name="number-of-volumes">cilt</term>
+      <term name="cited">a.g.e.</term>
     </terms>
   </locale>
   <macro name="editor-translator">
@@ -392,10 +394,10 @@
   </macro>
   <macro name="collection-title">
     <choose>
-      <if match="none" type="article-journal">
+      <if match="none" type="article-journal book">
         <choose>
           <if match="none" is-numeric="collection-number">
-            <group delimiter=", ">
+            <group delimiter=", " suffix=",">
               <text variable="collection-title" text-case="title"/>
               <text variable="collection-number"/>
             </group>
@@ -604,7 +606,9 @@
         <text macro="legal-cites"/>
       </else-if>
       <else-if type="book graphic motion_picture report song" match="any">
-        <text macro="edition"/>
+        <group delimiter=", ">
+          <text macro="edition"/>
+        </group>
       </else-if>
       <else-if type="chapter paper-conference" match="any">
         <group delimiter=". ">
@@ -647,7 +651,9 @@
   <macro name="event">
     <choose>
       <if variable="title">
-        <text variable="event"/>
+        <group delimiter=" ">
+          <text variable="event"/>
+        </group>
       </if>
       <else>
         <group delimiter=" ">
@@ -1017,38 +1023,26 @@
   </macro>
   <macro name="archive-note">
     <choose>
-      <if type="thesis">
+      <if type="manuscript">
         <group delimiter=" ">
           <text variable="archive"/>
           <text variable="archive_location" prefix="(" suffix=")"/>
-        </group>
-      </if>
-      <else>
-        <group delimiter=", ">
-          <text variable="archive"/>
-          <text variable="archive_location"/>
           <text variable="archive-place"/>
           <text variable="call-number"/>
         </group>
-      </else>
+      </if>
     </choose>
   </macro>
   <macro name="archive">
     <choose>
-      <if type="thesis">
+      <if type="manuscript">
         <group delimiter=" ">
           <text variable="archive"/>
           <text variable="archive_location" prefix=", (" suffix=")"/>
-        </group>
-      </if>
-      <else>
-        <group delimiter=", " prefix=", ">
-          <text variable="archive"/>
-          <text variable="archive_location" text-case="capitalize-first"/>
           <text variable="archive-place"/>
           <text variable="call-number"/>
         </group>
-      </else>
+      </if>
     </choose>
   </macro>
   <macro name="issue-note-join-with-space">
@@ -1325,7 +1319,16 @@
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
-        <if match="any" position="subsequent">
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <text term="cited" text-case="lowercase"/>
+            <text macro="point-locators-subsequent"/>
+          </group>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid" text-case="lowercase"/>
+        </else-if>
+        <else-if position="subsequent">
           <group delimiter=", ">
             <text macro="contributors-short"/>
             <group delimiter=" ">
@@ -1342,7 +1345,7 @@
               </if>
             </choose>
           </group>
-        </if>
+        </else-if>
         <else>
           <group delimiter=", ">
             <group delimiter=", ">

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-full-note.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-full-note.csl
@@ -14,7 +14,7 @@
     <category citation-format="note"/>
     <category field="social_science"/>
     <summary xml:lang="tr">Uludağ Üniversitesi Sosyal Bilimler Enstitüsü'nde yüksek lisans ve doktora tezi yazan öğrencilerimiz için tez yazım kılavuzuna uygun olarak hazırlanmıştır.</summary>
-    <updated>2017-10-09T21:12:24+00:00</updated>
+    <updated>2017-11-03T06:21:53+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="tr">
@@ -32,11 +32,9 @@
       </term>
       <term name="translator" form="short">çev.</term>
       <term name="edition" form="short">bs.</term>
-      <term name="ibid">a.yer</term>
-      <term name="issue" form="short">s.</term>
-      <term name="volume" form="short">c.</term>
+      <term name="issue" form="short">S.</term>
+      <term name="volume" form="short">C.</term>
       <term name="number-of-volumes">cilt</term>
-      <term name="cited">a.g.e.</term>
     </terms>
   </locale>
   <macro name="editor-translator">
@@ -394,10 +392,10 @@
   </macro>
   <macro name="collection-title">
     <choose>
-      <if match="none" type="article-journal">
+      <if match="none" type="article-journal book">
         <choose>
           <if match="none" is-numeric="collection-number">
-            <group delimiter=", ">
+            <group delimiter=", " suffix=",">
               <text variable="collection-title" text-case="title"/>
               <text variable="collection-number"/>
             </group>
@@ -651,7 +649,9 @@
   <macro name="event">
     <choose>
       <if variable="title">
-        <text variable="event"/>
+        <group delimiter=" ">
+          <text variable="event"/>
+        </group>
       </if>
       <else>
         <group delimiter=" ">
@@ -1021,38 +1021,26 @@
   </macro>
   <macro name="archive-note">
     <choose>
-      <if type="thesis">
+      <if type="manuscript">
         <group delimiter=" ">
           <text variable="archive"/>
           <text variable="archive_location" prefix="(" suffix=")"/>
-        </group>
-      </if>
-      <else>
-        <group delimiter=", ">
-          <text variable="archive"/>
-          <text variable="archive_location"/>
           <text variable="archive-place"/>
           <text variable="call-number"/>
         </group>
-      </else>
+      </if>
     </choose>
   </macro>
   <macro name="archive">
     <choose>
-      <if type="thesis">
+      <if type="manuscript">
         <group delimiter=" ">
           <text variable="archive"/>
           <text variable="archive_location" prefix=", (" suffix=")"/>
-        </group>
-      </if>
-      <else>
-        <group delimiter=", " prefix=", ">
-          <text variable="archive"/>
-          <text variable="archive_location" text-case="capitalize-first"/>
           <text variable="archive-place"/>
           <text variable="call-number"/>
         </group>
-      </else>
+      </if>
     </choose>
   </macro>
   <macro name="issue-note-join-with-space">
@@ -1329,16 +1317,7 @@
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
-        <if position="ibid-with-locator">
-          <group delimiter=", ">
-            <text term="cited" text-case="lowercase"/>
-            <text macro="point-locators-subsequent"/>
-          </group>
-        </if>
-        <else-if position="ibid">
-          <text term="ibid" text-case="lowercase"/>
-        </else-if>
-        <else-if position="subsequent">
+        <if match="any" position="subsequent">
           <group delimiter=", ">
             <text macro="contributors-short"/>
             <group delimiter=" ">
@@ -1355,7 +1334,7 @@
               </if>
             </choose>
           </group>
-        </else-if>
+        </if>
         <else>
           <group delimiter=", ">
             <group delimiter=", ">

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note.csl
@@ -14,7 +14,7 @@
     <category citation-format="note"/>
     <category field="social_science"/>
     <summary xml:lang="tr">Uludağ Üniversitesi Sosyal Bilimler Enstitüsü'nde yüksek lisans ve doktora tezi yazan öğrencilerimiz için tez yazım kılavuzuna uygun olarak hazırlanmıştır.</summary>
-    <updated>2017-10-09T21:05:58+00:00</updated>
+    <updated>2017-11-03T06:26:28+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="tr">
@@ -32,11 +32,9 @@
       </term>
       <term name="translator" form="short">çev.</term>
       <term name="edition" form="short">bs.</term>
-      <term name="ibid">a.yer</term>
       <term name="issue" form="short">sy.</term>
       <term name="volume" form="short">c.</term>
       <term name="number-of-volumes">cilt</term>
-      <term name="cited">a.g.e.</term>
       <term name="et-al">v.dğr.</term>
       <term name="et-al" form="short">v.dğr.</term>
     </terms>
@@ -396,7 +394,7 @@
   </macro>
   <macro name="collection-title">
     <choose>
-      <if match="none" type="article-journal">
+      <if match="none" type="article-journal book">
         <choose>
           <if match="none" is-numeric="collection-number">
             <group delimiter=", ">
@@ -608,7 +606,9 @@
         <text macro="legal-cites"/>
       </else-if>
       <else-if type="book graphic motion_picture report song" match="any">
-        <text macro="edition"/>
+        <group delimiter=", ">
+          <text macro="edition"/>
+        </group>
       </else-if>
       <else-if type="chapter paper-conference" match="any">
         <group delimiter=". ">
@@ -651,7 +651,9 @@
   <macro name="event">
     <choose>
       <if variable="title">
-        <text variable="event"/>
+        <group delimiter=" ">
+          <text variable="event"/>
+        </group>
       </if>
       <else>
         <group delimiter=" ">
@@ -1021,38 +1023,26 @@
   </macro>
   <macro name="archive-note">
     <choose>
-      <if type="thesis">
+      <if type="manuscript">
         <group delimiter=" ">
           <text variable="archive"/>
           <text variable="archive_location" prefix="(" suffix=")"/>
-        </group>
-      </if>
-      <else>
-        <group delimiter=", ">
-          <text variable="archive"/>
-          <text variable="archive_location"/>
           <text variable="archive-place"/>
           <text variable="call-number"/>
         </group>
-      </else>
+      </if>
     </choose>
   </macro>
   <macro name="archive">
     <choose>
-      <if type="thesis">
+      <if type="manuscript">
         <group delimiter=" ">
           <text variable="archive"/>
           <text variable="archive_location" prefix=", (" suffix=")"/>
-        </group>
-      </if>
-      <else>
-        <group delimiter=", " prefix=", ">
-          <text variable="archive"/>
-          <text variable="archive_location" text-case="capitalize-first"/>
           <text variable="archive-place"/>
           <text variable="call-number"/>
         </group>
-      </else>
+      </if>
     </choose>
   </macro>
   <macro name="issue-note-join-with-space">
@@ -1329,16 +1319,7 @@
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
-        <if position="ibid-with-locator">
-          <group delimiter=", ">
-            <text term="cited" text-case="lowercase"/>
-            <text macro="point-locators-subsequent"/>
-          </group>
-        </if>
-        <else-if position="ibid">
-          <text term="ibid" text-case="lowercase"/>
-        </else-if>
-        <else-if position="subsequent">
+        <if match="any" position="subsequent">
           <group delimiter=", ">
             <text macro="contributors-short"/>
             <group delimiter=" ">
@@ -1355,7 +1336,7 @@
               </if>
             </choose>
           </group>
-        </else-if>
+        </if>
         <else>
           <group delimiter=", ">
             <group delimiter=", ">


### PR DESCRIPTION

This update to Transactions of the American Philological Association style is more current:
(1) Escape coded the emdashes in the subsequent reference coding
(2) Used only initials on first and middle names of all authors and editors
(3) Fixed the book format for chapters to conform with TAPA guidelines
(4) Made journal name choose the short form, because TAPA requires abbreviations based on L'Annee Philologique.